### PR TITLE
modifies enrichment to leave enrichment

### DIFF
--- a/server/backend_go_enrichment.py
+++ b/server/backend_go_enrichment.py
@@ -3,9 +3,11 @@
 # needs snps of selection, snps of background, snp-gene-association,
 # gene-go-association, significance-level and go-hierarchy as input
 # Written by Sophie Pesch 2021
+# Modified by Mathias Witte Paz 2021 to match our expected GoEA
 
 import numpy as np
 from scipy.stats import fisher_exact
+# from icecream import ic
 
 
 #computes go-enrichment, adds descriptions for enriched go-terms
@@ -32,6 +34,8 @@ class GOEnrichment:
         tree_go_terms, in_gene_tree = self.__associated_go_terms(self.__tree_snps)
         clade_go_terms, in_gene_clade = self.__associated_go_terms(self.__clade_snps)
         for go_term in set(clade_go_terms):
+            if go_term == "No associated GO ID":
+                continue
             fishers_exact = self.__fishers_exact_test(go_term, tree_go_terms, clade_go_terms)
             if fishers_exact:
                 description = self.__go_to_description(go_term)
@@ -56,6 +60,8 @@ class GOEnrichment:
                 if gene in self.__gene_to_go_terms:
                     go_terms = self.__gene_to_go_terms[gene]
                     associated.extend(go_terms)
+                else:
+                    associated.extend(["No associated GO ID"])
         return associated, in_gene
 
     def __fill_contingency_table(self, go_term, go_terms_tree, go_terms_clade):

--- a/server/backend_nwk_parser.py
+++ b/server/backend_nwk_parser.py
@@ -3,8 +3,9 @@
 # of Evidente backend
 # Parses a given newick tree, provides tree traversal
 # Written by Sophie Pesch 2021
+# Modified by Mathias Witte Paz 2021 for leave saving
 
-
+# from icecream import ic
 import re
 #from backend_tree_enrichment import FindClades
 
@@ -22,6 +23,7 @@ class Tree:
         self.__number = number
         self.__children = children  # list of Trees
         self.__idx = 0  # helper counting nodes
+        # self.__leaves = []
 
 
     def parse_nwk_string(self, txt):
@@ -52,6 +54,17 @@ class Tree:
     def get_children(self):
         """returns children of top node"""
         return self.__children
+
+    def get_leaves(self):
+        """returns leaves from tree starting at top node"""
+        children = self.get_children()
+        if not children.__len__() > 0:
+            return [self.get_number()]
+        else:
+            leaves = []
+            for child in children:
+                leaves.extend(child.get_leaves())
+            return leaves
 
 
     def traverse_tree_func(self, enter_func, leave_func, data):
@@ -192,8 +205,11 @@ class Snps:
                      snp["node"] == self.__ids[str(node.get_number())]])
         if self.__stack.__len__() > 0:
             snps.extend(self.__node_to_snps[self.__stack[-1]])
-        self.__num_snps += snps.__len__()
-        self.__all_snps.extend(snps)
+        # Account only for snps that are found in leaves
+        # Others are just projections of SNPs
+        if not node.get_children():
+            self.__num_snps += snps.__len__()
+            self.__all_snps.extend(snps)
         return snps
 
     def leave(self, node):

--- a/src/App.js
+++ b/src/App.js
@@ -181,17 +181,20 @@ class App extends Component {
   }
 
   /**
-     *get position of all snps in subtree chosen by client
+     *get position of all snps found in leaves in subtree chosen by client
      *sets State variables subtree_snps, subtree_size to
      number of snps and number of nodes
      *returns list of positions
      **/
   getSnpOfSubtree = (node, subtree) => {
     let chosen = [];
-    chosen = chosen.concat(this.state.node_to_snps[node.tempid]);
+    if (!("children" in node)){
+      chosen = chosen.concat(this.state.node_to_snps[node.tempid]);
+    }
     subtree.forEach((sub_node) => {
+      if (!("children" in sub_node)){
       chosen = chosen.concat(this.state.node_to_snps[sub_node.tempid]);
-    });
+    }});
     this.setState({ subtree_size: subtree.length + 1 });
     this.setState({ subtree_snps: chosen.length });
     return chosen;


### PR DESCRIPTION
tree_enrichment: Adapts var allSNPs to only account SNPs appearing in the SNP table
go_enrichment: adapts var positions to only include SNPs from leaves
modifies Tree Class to save IDs of leaves
App.js - getSNPofSubtree: extraction of SNPs of a clade only if they are leaves
GOEnrichment - associated_go_terms: Adds case that an SNP is found within a gene but the gene is not associated to a GO ID, this ID is not accounted as an analysis by itself but counts for the background of the other analyses