### PR TITLE
Solves multithread problem

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -9,6 +9,8 @@ from server.backend_prepare_statistics import read_statistic_file_content, prepa
 from server.backend_compute_statistics import go_enrichment, tree_enrichment
 from flask import Flask, request, session, jsonify
 from markupsafe import escape
+import multiprocessing as mp
+
 import sys
 
 
@@ -191,4 +193,6 @@ def index():
     return app.send_static_file('index.html')
 
 if __name__ == "__main__":
+    mp.set_start_method('spawn')    
+
     app.run(debug=True, port=int("3001"))

--- a/server/backend_compute_statistics.py
+++ b/server/backend_compute_statistics.py
@@ -101,8 +101,6 @@ def tree_enrichment(nwk,support, num_to_lab, all_snps, node_to_snp, snps_to_gene
     #start_find_clades = perf_counter()
     tree = Tree()
     tree.parse_nwk_string(nwk)
-    #TODO: This part here filters the num of clades to only those where a sup SNP has been allocated. 
-    # TODO: Does this make sense?
     find_clades = FindClades(support, num_to_lab)
     tree.traverse_tree(find_clades)
     clades = find_clades.get_clades()

--- a/server/backend_compute_statistics.py
+++ b/server/backend_compute_statistics.py
@@ -110,7 +110,6 @@ def tree_enrichment(nwk,support, num_to_lab, all_snps, node_to_snp, snps_to_gene
     #end_find_clades = perf_counter()
     #time_find_clades = end_find_clades-start_find_clades
     #print(f"Needed {time_find_clades:0.4f} seconds for finding clades")
-    mp.set_start_method('spawn')    
     all_results = dict()
     in_gene_tree = ""
     with ThreadPool(int(mp.cpu_count()/2)) as pool:


### PR DESCRIPTION
sets context only once
Tree enrichment for Lepra ran 5 min using gunicorn locally. 
Tree enrichment in Syphilis ran for 40 min.
Does this solve the problem in the deployed version? 
TODO: merge dev with master and run syphilis' analysis there. increase timeout of gunicorn.
why does the analysis for syphilis take more time than for lepra? Lepra has more taxa and more GO-IDs. Syphilis has only 300 more SNPs than lepra -> Number of Sup. Clades might be larger in Syphilis. 