### PR TITLE
Correct pvalue correction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,4 @@ node_modules
 /server/.idea/
 /node_modules/
 package-lock.json
+.DS_Store

--- a/server/backend_go_enrichment.py
+++ b/server/backend_go_enrichment.py
@@ -10,7 +10,7 @@ from scipy.stats import fisher_exact
 # from icecream import ic
 
 
-#computes go-enrichment, adds descriptions for enriched go-terms
+# computes go-enrichment, adds descriptions for enriched go-terms
 class GOEnrichment:
     def __init__(self, tree_snps, clade_snps, snps_to_gene, gene_to_go_terms, sig_level, go_hierarchy):
         """construct go-enrichment object
@@ -31,25 +31,27 @@ class GOEnrichment:
     def compute_enrichment(self):
         # return dict:go-term -> p-value, description, e/p
         results = []
-        tree_go_terms, in_gene_tree = self.__associated_go_terms(self.__tree_snps)
-        clade_go_terms, in_gene_clade = self.__associated_go_terms(self.__clade_snps)
+        tree_go_terms, in_gene_tree = self.__associated_go_terms(
+            self.__tree_snps)
+        clade_go_terms, in_gene_clade = self.__associated_go_terms(
+            self.__clade_snps)
         for go_term in set(clade_go_terms.keys()):
             if go_term == "No associated GO ID":
                 continue
-            fishers_exact = self.__fishers_exact_test(go_term, tree_go_terms, clade_go_terms, in_gene_tree, in_gene_clade)
+            fishers_exact = self.__fishers_exact_test(
+                go_term, tree_go_terms, clade_go_terms, in_gene_tree, in_gene_clade)
             if fishers_exact:
                 description = self.__go_to_description(go_term)
                 results.append((go_term, fishers_exact, description))
-        #print(results.__len__())
-        results_sorted = sorted(results, key=lambda k:k[1])
+        # print(results.__len__())
+        results_sorted = sorted(results, key=lambda k: k[1])
         #print("in gene", in_gene_tree, in_gene_clade)
-        return results_sorted, set(clade_go_terms.keys()).__len__(),in_gene_clade, in_gene_tree
+        return results_sorted, set(clade_go_terms.keys()).__len__(), in_gene_clade, in_gene_tree
 
     def __go_to_description(self, go_term):
         if go_term in self.__go_hierarchy.keys():
             return self.__go_hierarchy[go_term]
         return ''
-
 
     def __associated_go_terms(self, snps):
         associated = {}
@@ -61,7 +63,7 @@ class GOEnrichment:
                 if gene in self.__gene_to_go_terms:
                     go_terms = self.__gene_to_go_terms[gene]
                     for go_term in go_terms:
-                        associated.setdefault(go_term,[]).append(snp)
+                        associated.setdefault(go_term, []).append(snp)
         return associated, in_gene
 
     def __fill_contingency_table(self, go_term, go_terms_tree, go_terms_clade, in_gene_tree, in_gene_clade):
@@ -72,13 +74,14 @@ class GOEnrichment:
         table = np.array([[a, b], [c, d]])
         return table
 
-    def __fishers_exact_test(self, go_term, go_terms_tree, go_terms_clade,in_gene_tree, in_gene_clade):
-        table = self.__fill_contingency_table(go_term,go_terms_tree,go_terms_clade,in_gene_tree, in_gene_clade)
+    def __fishers_exact_test(self, go_term, go_terms_tree, go_terms_clade, in_gene_tree, in_gene_clade):
+        table = self.__fill_contingency_table(
+            go_term, go_terms_tree, go_terms_clade, in_gene_tree, in_gene_clade)
         oddsratio, p_value = fisher_exact(table, alternative='greater')
         if p_value < self.__bonferroni_correction(go_terms_clade):
-            return p_value
+            # Values were not correctly corrected.
+            return p_value * go_terms_clade.__len__()
         return None
 
-
-    def __bonferroni_correction(self,go_terms_clade):
+    def __bonferroni_correction(self, go_terms_clade):
         return self.__sig_level / go_terms_clade.__len__()

--- a/src/components/welcome-modal.jsx
+++ b/src/components/welcome-modal.jsx
@@ -19,7 +19,7 @@ class WelcomeModal extends Component {
             >
                 <p style={{ textAlign: "justify" }}>
                     Evidente is loaded with a default toy example with seven samples, 28 SNPs and four
-                    different metadata, in order for you to get to know this tool. Furtherer example datasets can be used from the
+                    different metadata, in order for you to get to know this tool. Further example datasets can be selected from the
                     menu <span style={{ fontStyle: "italic" }}>Example Datasets</span>.
                     In order to upload your own files, please direct yourself to
                     the "Load files" menu.


### PR DESCRIPTION
 Until this point it was only tested if p-value < alpha', with alpha' = alpha / # number of comparisons. Adapts p-value correction to show p-value * # of comparisons = q-value.
Also corrects a typo.